### PR TITLE
Decrease spork version requirement

### DIFF
--- a/guard-spork.gemspec
+++ b/guard-spork.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = 'guard-spork'
   
   s.add_dependency 'guard',   '>= 0.2.0'
-  s.add_dependency 'spork',   '~> 0.9.0.rc2'
+  s.add_dependency 'spork',   '>= 0.8.4'
   
   s.add_development_dependency 'bundler', '~> 1.0.3'
   s.add_development_dependency 'rspec',   '~> 2.1'


### PR DESCRIPTION
Newer versions of spork require RSpec 2, which can only be used with Rails 3 due to dependencies in rspec-rails 2.

As guard-spork works with spork 0.8.4 I think reducing the version dependency in guard-spork's gemspec is a nice thing to do.

Sorry about not creating a feature branch. I literally edited the message via Github and commited it without cloning the repo to my local machine.

Regards,
James
