### PR TITLE
recover Ruby 1.8 compatibility

### DIFF
--- a/guard-spork.gemspec
+++ b/guard-spork.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   
   s.add_dependency 'guard',   '>= 0.2.2'
   s.add_dependency 'spork',   '>= 0.8.4'
+  s.add_dependency 'sfl',     '= 1.2'
   
   s.add_development_dependency 'bundler',     '~> 1.0.7'
   s.add_development_dependency 'rspec',       '~> 2.2.0'

--- a/lib/guard/spork/runner.rb
+++ b/lib/guard/spork/runner.rb
@@ -1,4 +1,5 @@
 require 'socket'
+require 'sfl'
 
 module Guard
   class Spork


### PR DESCRIPTION
guard/guard-spork@51eb32ccf7ace07f6928c3c55d8c1745e129e191 uses `spawn` that is Ruby 1.9 feature and broke the 1.8 compatibility. (sorry, I didn't meant to make the patch public, it was for a specific use.)

the attached commit recovers 1.8 compatibility, using sfl (spawn-for-legacy).
