### PR TITLE
Changing cucumber environment to TEST because rails g cucumber

### DIFF
--- a/lib/guard/spork/templates/Guardfile
+++ b/lib/guard/spork/templates/Guardfile
@@ -1,4 +1,4 @@
-guard 'spork', :cucumber_env => { 'RAILS_ENV' => 'cucumber' }, :rspec_env => { 'RAILS_ENV' => 'test' } do
+guard 'spork', :cucumber_env => { 'RAILS_ENV' => 'test' }, :rspec_env => { 'RAILS_ENV' => 'test' } do
   watch('config/application.rb')
   watch('config/environment.rb')
   watch(%r{^config/environments/.+\.rb$})


### PR DESCRIPTION
Changing cucumber environment to TEST because (bundle exec) rake cucumber:install no longer generates config/environments/cucumber.rb and thus, guard fails out of the box
