### PR TITLE
Weird naming conflict with Process and Guard::Process when using the guard-process gem with this one.

### DIFF
--- a/lib/guard/spork/runner.rb
+++ b/lib/guard/spork/runner.rb
@@ -29,7 +29,7 @@ module Guard
 
       def kill_sporks
         UI.debug "Killing Spork servers with PID: #{spork_pids.join(', ')}"
-        spork_pids.each { |pid| Process.kill("KILL", pid) }
+        spork_pids.each { |pid| ::Process.kill("KILL", pid) }
       end
 
     private
@@ -85,7 +85,7 @@ module Guard
         stats = []
         loop do
           begin
-            pid, stat = Process.wait2(-1, Process::WNOHANG)
+            pid, stat = ::Process.wait2(-1, ::Process::WNOHANG)
             break if pid.nil?
             stats << stat
           rescue Errno::ECHILD


### PR DESCRIPTION
For some reason the Process constant in this file, is actually referencing the Guard::Process constant in the guard-process gem. Force Process to refer to the top-most scope.
