### PR TITLE
quiet option for spork

### DIFF
--- a/lib/guard/spork/runner.rb
+++ b/lib/guard/spork/runner.rb
@@ -15,6 +15,7 @@ module Guard
         options[:test_unit_env]  ||= {}
         options[:cucumber_env]   ||= {}
         options[:aggressive_kill]  = true unless options[:aggressive_kill] == false
+        options[:quiet]            = false unless options[:quiet] == true
         @options  = options
         initialize_spork_instances
       end
@@ -55,7 +56,7 @@ module Guard
         @spork_instances = []
         [:rspec, :cucumber, :test_unit].each do |type|
           port, env = options[:"#{type}_port"], options[:"#{type}_env"]
-          spork_instances << SporkInstance.new(type, port, env, :bundler => should_use?(:bundler)) if should_use?(type)
+          spork_instances << SporkInstance.new(type, port, env, { :bundler => should_use?(:bundler), :quiet => options[:quiet] }) if should_use?(type)
         end
       end
 

--- a/lib/guard/spork/spork_instance.rb
+++ b/lib/guard/spork/spork_instance.rb
@@ -59,6 +59,7 @@ module Guard
         end
 
         parts << "-p #{port}"
+        parts << "-q" if options[:quiet]
         parts.join(" ")
       end
 


### PR DESCRIPTION
This adds a very simple quiet option for launching spork server to omit the "Running tests with args #{argv.inspect}..." and "Done.\n\n" 

In your Guardfile start spork with:

```
    guard 'spork', :quiet => true do
      ...
    end
```

here's the related pull request for spork that makes this work: 
https://github.com/sporkrb/spork/pull/163
