### PR TITLE
Force use of global namespaced Process class

### DIFF
--- a/lib/guard/spork/runner.rb
+++ b/lib/guard/spork/runner.rb
@@ -50,7 +50,7 @@ module Guard
 
       def kill_pids(pids)
         UI.debug "Killing Spork servers with PID: #{pids.join(', ')}"
-        pids.each { |pid| Process.kill("KILL", pid) }
+        pids.each { |pid| ::Process.kill("KILL", pid) }
       end
 
       def ps_spork_pids

--- a/lib/guard/spork/spork_instance.rb
+++ b/lib/guard/spork/spork_instance.rb
@@ -30,7 +30,7 @@ module Guard
       end
 
       def stop
-        Process.kill('KILL', pid)
+        ::Process.kill('KILL', pid)
       end
 
       def alive?
@@ -71,11 +71,11 @@ module Guard
       end
 
     private
-    
+
       def use_bundler?
         options[:bundler]
       end
-      
+
     end
   end
 end


### PR DESCRIPTION
I was using guard-spork 0.4.x with guard-process and got a clash on the Process class (the Guard::Process class from guard-process got called instead of Process), this pull request will ensure that guard-spork always uses the global Process class.

I'd appreciate it if you would be willing to merge this into guard-process :)
