### PR TITLE
Ensure that all Process calls are made to the global namespace

### DIFF
--- a/lib/guard/spork/spork_instance.rb
+++ b/lib/guard/spork/spork_instance.rb
@@ -35,7 +35,7 @@ module Guard
 
       def alive?
         return false unless pid
-        Process.waitpid(pid, Process::WNOHANG).nil?
+        ::Process.waitpid(pid, ::Process::WNOHANG).nil?
       end
 
       def running?


### PR DESCRIPTION
As mentioned in #59, some parts of this gem conflicts with guard-process since the Process calls aren't made to the global namespace. The pull request in #59 fixes some of these issues, but there was still an issue that appeared when Guard was reloading (for instance after re-evaluating the Guardfile).
