### PR TITLE
Foreman .env integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ guard 'spork', :cucumber_env => { 'RAILS_ENV' => 'cucumber' }, :rspec_env => { '
 end
 ```
 
+If your application runs on [Heroku](http://www.heroku.com/) or otherwise uses [Foreman](https://github.com/ddollar/foreman), you can provide the `:foreman => true` option to have environment variables present in the `.env` file passed on to the Spork server.
+
 Available options:
 
 ``` ruby
@@ -107,6 +109,7 @@ Available options:
 :cucumber_env => { 'RAILS_ENV' => 'bar' }  # Default: nil
 :aggressive_kill => false                  # Default: true, will search Spork pids from `ps aux` and kill them all on start.
 :notify_on_start => true                   # Default: false, will notify as soon as starting begins.
+:foreman => true                           # Default: false, will start Spork through `foreman run` to pick up environment variables used by Foreman.
 ```
 
 ## Common troubleshooting

--- a/lib/guard/spork/runner.rb
+++ b/lib/guard/spork/runner.rb
@@ -18,6 +18,7 @@ module Guard
         options[:minitest_env]   ||= {}
         options[:minitest]       ||= false
         options[:aggressive_kill]  = true unless options[:aggressive_kill] == false
+        options[:foreman]        ||= false
         @options  = options
         initialize_spork_instances
       end
@@ -50,7 +51,7 @@ module Guard
         @spork_instances = []
         [:rspec, :cucumber, :test_unit, :minitest].each do |type|
           port, env = options[:"#{type}_port"], options[:"#{type}_env"]
-          spork_instances << SporkInstance.new(type, port, env, :bundler => should_use?(:bundler)) if should_use?(type)
+          spork_instances << SporkInstance.new(type, port, env, :bundler => should_use?(:bundler), :foreman => should_use?(:foreman)) if should_use?(type)
         end
       end
 
@@ -124,9 +125,13 @@ module Guard
       def detect_minitest
         false
       end
-      
+
       def detect_cucumber
         File.exist?("features")
+      end
+
+      def detect_foreman
+        File.exist?("Procfile")
       end
     end
   end

--- a/lib/guard/spork/spork_instance.rb
+++ b/lib/guard/spork/spork_instance.rb
@@ -51,6 +51,7 @@ module Guard
       def command
         parts = []
         parts << "bundle exec" if use_bundler?
+        parts << "foreman run" if use_foreman?
         parts << "spork"
 
         if type == :test_unit
@@ -78,6 +79,10 @@ module Guard
 
       def use_bundler?
         options[:bundler]
+      end
+
+      def use_foreman?
+        options[:foreman]
       end
 
     end

--- a/spec/guard/spork/runner_spec.rb
+++ b/spec/guard/spork/runner_spec.rb
@@ -16,6 +16,7 @@ describe Guard::Spork::Runner do
     it { should include(:minitest => false) }
     it { should include(:cucumber_env => {}) }
     it { should include(:aggressive_kill => true) }
+    it { should include(:foreman => false) }
   end
 
   before(:each) do

--- a/spec/guard/spork/spork_instance_spec.rb
+++ b/spec/guard/spork/spork_instance_spec.rb
@@ -20,6 +20,12 @@ class Guard::Spork
 
         its(:command) { should == "bundle exec spork -p 1337" }
       end
+
+      context "with foreman enabled" do
+        let(:options) { { :foreman => true, :bundler => true } }
+
+        its(:command) { should == "bundle exec foreman run spork -p 1337"}
+      end
     end
 
     describe "cucumber on port 1337" do
@@ -35,6 +41,12 @@ class Guard::Spork
         let(:options) { {:bundler => true} }
 
         its(:command) { should == "bundle exec spork cu -p 1337" }
+      end
+
+      context "with foreman enabled" do
+        let(:options) { { :foreman => true, :bundler => true } }
+
+        its(:command) { should == "bundle exec foreman run spork cu -p 1337"}
       end
     end
 
@@ -52,8 +64,14 @@ class Guard::Spork
 
         its(:command) { should == "bundle exec spork testunit -p 1337" }
       end
+
+      context "with foreman enabled" do
+        let(:options) { { :foreman => true, :bundler => true } }
+
+        its(:command) { should == "bundle exec foreman run spork testunit -p 1337"}
+      end
     end
-    
+
     describe "minitest on port 1338" do
       let(:options) { Hash.new }
       subject { SporkInstance.new(:minitest, 1338, {}, options) }
@@ -68,8 +86,14 @@ class Guard::Spork
 
         its(:command) { should == "bundle exec spork minitest -p 1338" }
       end
+
+      context "with foreman enabled" do
+        let(:options) { { :foreman => true, :bundler => true } }
+
+        its(:command) { should == "bundle exec foreman run spork minitest -p 1338"}
+      end
     end
-    
+
   end
 
   describe SporkInstance, "spawning" do


### PR DESCRIPTION
This patch adds a new option `:foreman` to `Guard::Spork`. When set, the `spork` command will be altered to include `foreman run` at the beginning (but after `bundle exec`). This mixes in any environment variables included in Foreman's `.env` file. It's very useful for applications which are deployed to Heroku.
