### PR TITLE
Guard spork should not send KILL signal in stop

### DIFF
--- a/lib/guard/spork/spork_instance.rb
+++ b/lib/guard/spork/spork_instance.rb
@@ -32,7 +32,7 @@ module Guard
       end
 
       def stop
-        ::Process.kill('KILL', pid)
+        ::Process.kill('TERM', pid)
       end
 
       def alive?

--- a/spec/guard/spork/spork_instance_spec.rb
+++ b/spec/guard/spork/spork_instance_spec.rb
@@ -154,9 +154,9 @@ class Guard::Spork
     end
 
     describe "#stop" do
-      it "kills the pid" do
+      it "kills the pid using SIGTERM" do
         instance.stub(:pid => 42)
-        Process.should_receive(:kill).with('KILL', 42)
+        Process.should_receive(:kill).with('TERM', 42)
         instance.stop
       end
     end


### PR DESCRIPTION
I'm trying to debug [this issue](https://github.com/justinko/sunspot-rails-tester/issues/3) and [I found](https://github.com/guard/guard/issues/276#issuecomment-5268034) that at_exit callback of that gem is not executed because guard-spork [sends a SIGKILL](https://github.com/guard/guard-spork/blob/master/lib/guard/spork/spork_instance.rb#L35) to the spork process.

Is it possible to change the SIGKILL to a more conventional SIGTERM in order to avoid that kind of issues? Is there any drawback in doing that?
