### PR TITLE
Windows support

### DIFF
--- a/guard-spork.gemspec
+++ b/guard-spork.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'guard', '>= 1.1'
   s.add_dependency 'spork', '>= 0.8.4'
+  s.add_dependency 'childprocess'
+  s.add_dependency 'sys-proctable'
 
   s.add_development_dependency 'bundler',     '~> 1.0'
   s.add_development_dependency 'rspec',       '~> 2.10'

--- a/lib/guard/spork.rb
+++ b/lib/guard/spork.rb
@@ -1,5 +1,8 @@
 require 'guard'
 require 'guard/guard'
+require 'sys/proctable'
+require 'childprocess'
+require 'rinda/ring'
 
 module Guard
   class Spork < Guard

--- a/lib/guard/spork/spork_instance.rb
+++ b/lib/guard/spork/spork_instance.rb
@@ -1,7 +1,7 @@
 module Guard
   class Spork
     class SporkInstance
-      attr_reader :type, :env, :port, :options, :pid
+      attr_reader :type, :env, :port, :options, :pid, :process
 
       def initialize(type, port, env, options)
         @type = type
@@ -26,24 +26,39 @@ module Guard
       end
 
       def start
-        @pid = fork do
-          env_exec env, command
+        cmd = [command]
+
+        if self.class.windows?
+          cmd = ["cmd", "/C"] + cmd
         end
+
+        @process = ChildProcess.build *cmd
+        @process.environment.merge!(env)
+        @process.io.inherit!
+        @process.start
+        @pid = @process.pid
       end
 
       def stop
-        ::Process.kill('TERM', pid)
+        unless self.class.windows?
+          process.stop
+        else
+          kill_all_child_processes
+        end
       end
 
       def alive?
-        return false unless pid
-        ::Process.waitpid(pid, ::Process::WNOHANG).nil?
+        pid && process.alive?
       end
 
       def running?
-        return false unless pid
+        return false unless alive?
         TCPSocket.new('localhost', port).close
-        true
+        if self.class.windows?
+          running_on_windows?
+        else
+          true
+        end
       rescue Errno::ECONNREFUSED
         false
       end
@@ -67,13 +82,8 @@ module Guard
         parts.join(" ")
       end
 
-      def env_exec(environment, command)
-        if RUBY_VERSION > "1.9"
-          exec environment, command
-        else
-          environment.each_pair { |key, value| ENV[key] = value }
-          exec command
-        end
+      def self.windows?
+        RUBY_PLATFORM =~ /mswin|msys|mingw/
       end
 
     private
@@ -84,6 +94,26 @@ module Guard
 
       def use_foreman?
         options[:foreman]
+      end
+
+      def kill_all_child_processes
+        all_pids_for(pid).each do |pid|
+          Process.kill 9, pid
+        end
+      end
+
+      def all_pids_for(parent_pid)
+        pids = [parent_pid]
+        Sys::ProcTable.ps do |process|
+          pids += all_pids_for(process.pid) if process.ppid == parent_pid
+        end
+        pids
+      end
+
+      def running_on_windows?
+        DRb.start_service
+        ts = Rinda::RingFinger.primary
+        size = ts.read_all([:name, :MagazineSlave, nil, nil]).size > 0
       end
 
     end

--- a/lib/guard/spork/spork_instance.rb
+++ b/lib/guard/spork/spork_instance.rb
@@ -112,8 +112,13 @@ module Guard
 
       def running_on_windows?
         DRb.start_service
+        # make sure that ringfinger is not taken from cache, because it won't
+        # work after guard-spork has been restarted
+        Rinda::RingFinger.class_variable_set :@@finger, nil
         ts = Rinda::RingFinger.primary
-        size = ts.read_all([:name, :MagazineSlave, nil, nil]).size > 0
+        ts.read_all([:name, :MagazineSlave, nil, nil]).size > 0
+      rescue DRb::DRbConnError
+        false
       end
 
     end

--- a/spec/guard/spork/runner_spec.rb
+++ b/spec/guard/spork/runner_spec.rb
@@ -411,7 +411,7 @@ describe Guard::Spork::Runner do
         runner.kill_global_sporks
       end
 
-      it "calls a KILL command for each Spork server running on the system" do
+      it "calls a KILL command for each Spork server running on the system", :unless => Guard::Spork::SporkInstance.windows? do
         # This is pretty hard to stub right now. We're hardcoding the command here
         runner.stub(:`).and_return { |command| raise "Unexpected command: #{command}" }
         runner.should_receive(:`).with("ps aux | awk '/spork/&&!/awk/{print $2;}'").and_return("666\n999")


### PR DESCRIPTION
Hi!

I've added a support for Windows by using childprocess and sys-proctable gems.

All specs are green on my win7 ruby 1.9.3 machine, but i have to admit, that i had not any VM-s available to run those specs on unix. If they pass for you and you can use guard-spork with your projects then i'd be happy to say that Windows users can use guard-spork too - at least it has been running fine on my rails project too.

Since Spork uses different run strategy on Windows then i needed to add a check for RingServer availability to determine if Spork is running.

It is related with #47 and #34
