### PR TITLE
Patch for Rinda::RingFinger.primary

### DIFF
--- a/lib/guard/spork.rb
+++ b/lib/guard/spork.rb
@@ -3,6 +3,7 @@ require 'guard/guard'
 require 'sys/proctable'
 require 'childprocess'
 require 'rinda/ring'
+require 'guard/spork/rinda_ring_finger_patch'
 
 module Guard
   class Spork < Guard

--- a/lib/guard/spork/rinda_ring_finger_patch.rb
+++ b/lib/guard/spork/rinda_ring_finger_patch.rb
@@ -1,0 +1,26 @@
+# Patch for Rinda::RingFinger.primary hanging forever on Ruby 1.9.2 & 1.9.3
+# from http://www.ruby-forum.com/topic/4229908
+require 'rinda/ring'
+
+module Rinda
+  class RingFinger
+    def lookup_ring_any(timeout=5)
+      queue = Queue.new
+
+      Thread.new do
+        self.lookup_ring(timeout) do |ts|
+          queue.push(ts)
+        end
+        queue.push(nil)
+      end
+
+      @primary = queue.pop
+      raise('RingNotFound') if @primary.nil?
+      while it = queue.pop
+        @rings.push(it)
+      end
+
+      @primary
+    end
+  end
+end

--- a/lib/guard/spork/spork_instance.rb
+++ b/lib/guard/spork/spork_instance.rb
@@ -117,7 +117,7 @@ module Guard
         Rinda::RingFinger.class_variable_set :@@finger, nil
         ts = Rinda::RingFinger.primary
         ts.read_all([:name, :MagazineSlave, nil, nil]).size > 0
-      rescue DRb::DRbConnError
+      rescue
         false
       end
 


### PR DESCRIPTION
Patch for Rinda::RingFinger.primary hanging forever on Ruby 1.9.2 & 1.9.3 from http://www.ruby-forum.com/topic/4229908

Without this patch i'm seeing the symptoms of Rinda::RingFinger.primary blocking forever.
