### PR TITLE
Use specific .env file on running with foreman.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Available options:
 :cucumber_env => { 'RAILS_ENV' => 'bar' }  # Default: nil
 :aggressive_kill => false                  # Default: true, will search Spork pids from `ps aux` and kill them all on start.
 :notify_on_start => true                   # Default: false, will notify as soon as starting begins.
-:foreman => true                           # Default: false, will start Spork through `foreman run` to pick up environment variables used by Foreman.
+:foreman => true                           # Default: false, will start Spork through `foreman run` to pick up environment variables used by Foreman. Pass an env file {:env => ".env.test"}
 :quiet => true                             # Default: false, will silence some of the debugging output which can get repetitive (only work with Spork edge at the moment).
 ```
 

--- a/lib/guard/spork/spork_instance.rb
+++ b/lib/guard/spork/spork_instance.rb
@@ -62,6 +62,7 @@ module Guard
 				if use_foreman?
 					parts << "foreman"
 					parts << "run"
+          parts << "-e=#{options[:foreman].fetch(:env, '.env')}" if foreman_options?
 				end
         parts << "spork"
 
@@ -91,6 +92,10 @@ module Guard
 
       def use_foreman?
         options[:foreman]
+      end
+
+      def foreman_options?
+        options[:foreman].is_a?(Hash)
       end
 
     end

--- a/spec/guard/spork/spork_instance_spec.rb
+++ b/spec/guard/spork/spork_instance_spec.rb
@@ -54,6 +54,12 @@ class Guard::Spork
 
         its(:command) { should == %w{bundle exec foreman run spork cu -p 1337} }
       end
+
+      context "with foreman enabled and env name option" do
+        let(:options) { { :foreman => { :env => ".env.test" }, :bundler => true } }
+
+        its(:command) { should == %w{bundle exec foreman run -e=.env.test spork cu -p 1337}}
+      end
     end
 
     describe "test_unit on port 1337" do
@@ -76,6 +82,12 @@ class Guard::Spork
 
         its(:command) { should == %w{bundle exec foreman run spork testunit -p 1337} }
       end
+
+      context "with foreman enabled and env name option" do
+        let(:options) { { :foreman => { :env => ".env.test" }, :bundler => true } }
+
+        its(:command) { should == %w{bundle exec foreman run -e=.env.test spork testunit -p 1337}}
+      end
     end
 
     describe "minitest on port 1338" do
@@ -97,6 +109,12 @@ class Guard::Spork
         let(:options) { { :foreman => true, :bundler => true } }
 
         its(:command) { should == %w{bundle exec foreman run spork minitest -p 1338}}
+      end
+
+      context "with foreman enabled and env name option" do
+        let(:options) { { :foreman => { :env => ".env.test" }, :bundler => true } }
+
+        its(:command) { should == %w{bundle exec foreman run -e=.env.test spork minitest -p 1338}}
       end
     end
 


### PR DESCRIPTION
Now user can set :foreman => { :env => ".env.test" } for loading .env.test file on running specs for example.
