### PR TITLE
Add foreman options at the end of arguments line

### DIFF
--- a/lib/guard/spork/spork_instance.rb
+++ b/lib/guard/spork/spork_instance.rb
@@ -64,7 +64,6 @@ module Guard
 				if use_foreman?
 					parts << "foreman"
 					parts << "run"
-          parts << "-e=#{options[:foreman].fetch(:env, '.env')}" if foreman_options?
 				end
         parts << "spork"
 
@@ -79,6 +78,11 @@ module Guard
         parts << "-p"
 			 	parts <<	port.to_s
         parts << "-q" if options[:quiet]
+
+        if use_foreman?
+          parts << "-e=#{options[:foreman].fetch(:env, '.env')}" if foreman_options?
+        end
+
         parts
       end
 

--- a/spec/guard/spork/spork_instance_spec.rb
+++ b/spec/guard/spork/spork_instance_spec.rb
@@ -58,7 +58,7 @@ class Guard::Spork
       context "with foreman enabled and env name option" do
         let(:options) { { :foreman => { :env => ".env.test" }, :bundler => true } }
 
-        its(:command) { should == %w{bundle exec foreman run -e=.env.test spork cu -p 1337}}
+        its(:command) { should == %w{bundle exec foreman run spork cu -p 1337 -e=.env.test}}
       end
     end
 
@@ -86,7 +86,7 @@ class Guard::Spork
       context "with foreman enabled and env name option" do
         let(:options) { { :foreman => { :env => ".env.test" }, :bundler => true } }
 
-        its(:command) { should == %w{bundle exec foreman run -e=.env.test spork testunit -p 1337}}
+        its(:command) { should == %w{bundle exec foreman run spork testunit -p 1337 -e=.env.test}}
       end
     end
 
@@ -114,7 +114,7 @@ class Guard::Spork
       context "with foreman enabled and env name option" do
         let(:options) { { :foreman => { :env => ".env.test" }, :bundler => true } }
 
-        its(:command) { should == %w{bundle exec foreman run -e=.env.test spork minitest -p 1338}}
+        its(:command) { should == %w{bundle exec foreman run spork minitest -p 1338 -e=.env.test}}
       end
     end
 


### PR DESCRIPTION
For some reasons `bundle exec foreman run -e=.env.test spork` skipped the next arguments 
