### PR TITLE
Add retry_delay option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Available options:
 
 ``` ruby
 :wait => 60                                # Seconds to wait for the server to start, default: 30. Setting it to nil will cause it to wait indefinitely.
+:retry_delay => 60                         # Seconds to wait before retrying booting the server, default: 30. Setting it to nil will cause it to wait indefinitely.
 :cucumber => false
 :rspec => false
 :test_unit => false

--- a/lib/guard/spork/runner.rb
+++ b/lib/guard/spork/runner.rb
@@ -8,6 +8,7 @@ module Guard
 
       def initialize(options={})
         options[:wait]           ||= 30 # seconds
+        options[:retry_delay]    ||= 2 * options[:wait] # seconds
         options[:test_unit_port] ||= 8988
         options[:cucumber_port]  ||= 8990
         options[:rspec_port]     ||= 8989
@@ -86,9 +87,9 @@ module Guard
           Notifier.notify "#{names} successfully #{action}ed", :title => "Spork", :image => :success
         else
           UI.reset_line # workaround before Guard::UI update
-          UI.error "Could not #{action} Spork server for #{names} after #{options[:wait]} seconds. I will continue waiting for a further 60 seconds."
-          Notifier.notify "#{names} NOT #{action}ed. Continuing to wait for 60 seconds.", :title => "Spork", :image => :failed
-          if wait_for_launch(instances, 60)
+          UI.error "Could not #{action} Spork server for #{names} after #{options[:wait]} seconds. I will continue waiting for a further #{options[:retry_delay]} seconds."
+          Notifier.notify "#{names} NOT #{action}ed. Continuing to wait for #{options[:retry_delay]} seconds.", :title => "Spork", :image => :failed
+          if wait_for_launch(instances, options[:retry_delay])
             total_time = Time.now - start_time
             UI.info "Spork server for #{names} eventually #{action}ed after #{total_time.to_i} seconds. Consider adjusting your :wait option beyond this time.", :reset => true
             Notifier.notify "#{names} eventually #{action}ed after #{total_time.to_i} seconds", :title => "Spork", :image => :success

--- a/spec/guard/spork/runner_spec.rb
+++ b/spec/guard/spork/runner_spec.rb
@@ -330,6 +330,18 @@ describe Guard::Spork::Runner do
         }.to throw_symbol(:task_has_failed)
       end
 
+      it "does not wait longer than the configured wait duration + retry_delay" do
+        runner.options[:wait] = 7
+        runner.options[:retry_delay] = 10
+        runner.should_receive(:sleep).with(1).exactly(17).times
+        rspec_instance.stub(:running? => false)
+        cucumber_instance.stub(:running? => true)
+
+        expect {
+          runner.launch_sporks("")
+        }.to throw_symbol(:task_has_failed)
+      end
+
       context "when :wait is nil" do
         it "does not time out" do
           runner.options[:wait] = nil
@@ -372,6 +384,19 @@ describe Guard::Spork::Runner do
       it "does not wait longer than the configured wait duration + 60" do
         runner.options[:wait] = 7
         runner.should_receive(:sleep).with(1).exactly(67).times
+        rspec_instance.stub(:running? => false)
+
+        cucumber_instance.should_not_receive(:running?)
+        expect {
+          runner.launch_sporks("", :rspec)
+        }.to throw_symbol(:task_has_failed)
+      end
+
+      # This behavior is a bit weird, isn't it?
+      it "does not wait longer than the configured wait duration + retry_delay" do
+        runner.options[:wait] = 7
+        runner.options[:retry_delay] = 10
+        runner.should_receive(:sleep).with(1).exactly(17).times
         rspec_instance.stub(:running? => false)
 
         cucumber_instance.should_not_receive(:running?)


### PR DESCRIPTION
Add retry_delay option. After a failed attempt to connect to the server, it will wait options[:retry_delay] seconds before trying to boot the server again. It defaults to options[:wait]
