### PR TITLE
Remove watch of Gemfile to avoid problems on (permanent) restarts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ guard 'spork' do
   watch('config/environment.rb')
   watch(%r{^config/environments/.*\.rb$})
   watch(%r{^config/initializers/.*\.rb$})
-  watch('Gemfile')
   watch('Gemfile.lock')
   watch('spec/spec_helper.rb') { :rspec }
   watch('test/test_helper.rb') { :test_unit }

--- a/lib/guard/spork/templates/Guardfile
+++ b/lib/guard/spork/templates/Guardfile
@@ -3,7 +3,6 @@ guard 'spork', :cucumber_env => { 'RAILS_ENV' => 'test' }, :rspec_env => { 'RAIL
   watch('config/environment.rb')
   watch('config/environments/test.rb')
   watch(%r{^config/initializers/.+\.rb$})
-  watch('Gemfile')
   watch('Gemfile.lock')
   watch('spec/spec_helper.rb') { :rspec }
   watch('test/test_helper.rb') { :test_unit }


### PR DESCRIPTION
Hi, I know you're searching for a maintainer, but this fix is easy and you could quickly think about it.

I always run into this problem:
As soon as I edit `Gemfile`, spork will restart itself.
Additionally, together with guard-rails, it tries restarts rails as well (as a side effect of restarting spork) which doesn't work because there are gems missing.
It always runs into this loop:

```
23:49:27 - INFO - Reloading Spork for RSpec
Could not find gem 'rails-i18n (>= 0) ruby' in the gems available on this machine.
Run `bundle install` to install missing gems.
23:49:57 - ERROR - Could not reload Spork server for RSpec after 30 seconds. I will continue waiting for a further 60 seconds.

23:50:57 - ERROR - Could not reload Spork server for RSpec. Make sure you can use it manually first.

23:52:52 - INFO - Restarting Rails...

Could not find gem 'rails-i18n (>= 0) ruby' in the gems available on this machine.
Run `bundle install` to install missing gems.
23:53:25 - INFO - Rails NOT restarted, check your log files.
```

and continues.
Now imho, watching `Gemfile` doesn't make sense since it doesn't affect the app immediately. Only `Gemfile.lock` is important for that.
After removing `watch(Gemfile)` I have time to run `bundle install` which will, on success, immediately restart sport (and rails and so on).

Now you could also add guard-bundler at the top of spork to first create `Gemfile.lock`, which will trigger spork. (However, I don't want that for now).
