### PR TITLE
Inherit from Guard::Plugin instead of deprecated Guard::Guard.

### DIFF
--- a/lib/guard/spork.rb
+++ b/lib/guard/spork.rb
@@ -1,16 +1,16 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 require 'childprocess'
 
 module Guard
-  class Spork < Guard
+  class Spork < Plugin
 
     autoload :Runner, 'guard/spork/runner'
     autoload :SporkInstance, 'guard/spork/spork_instance'
     autoload :SporkWindowsInstance, 'guard/spork/spork_windows_instance'
     attr_accessor :runner
 
-    def initialize(watchers=[], options={})
+    def initialize(options={})
       super
       @runner = Runner.new(options)
     end

--- a/spec/guard/spork_spec.rb
+++ b/spec/guard/spork_spec.rb
@@ -10,7 +10,7 @@ describe Guard::Spork do
 
     it "instantiates Runner with the given options" do
       Guard::Spork::Runner.should_receive(:new).with(:bundler => false).and_return(runner)
-      Guard::Spork.new [], :bundler => false
+      Guard::Spork.new :bundler => false
     end
   end
 


### PR DESCRIPTION
I followed the guide and inherit from Guard::Plugin instead of deprecated Guard::Guard:

https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#changes-in-guardguard
