### PR TITLE
Use latest guard when changed minor version on guard

### DIFF
--- a/guard-spork.gemspec
+++ b/guard-spork.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'guard-spork'
 
-  s.add_dependency 'guard', '~> 2.8.2'
+  s.add_dependency 'guard', '~> 2.0'
   s.add_dependency 'spork', '>= 0.8.4'
   s.add_dependency 'childprocess', '>= 0.2.3'
 


### PR DESCRIPTION
Install old guard-spork(1.5.1) when I wrote following Gemfile caused by dependency conflict.

```
source 'https://rubygems.org'

gem 'guard-rubocop'
gem 'guard-spork'
```

guard-spork require guard(2.8.x) in gemspec.
some plugin gems of guard require latest guard(2.x) in their gemspec.(ex yujinakayama/guard-rubocop )

We can pass our specs without error when use guard(2.9.0) and guard-spork(2.0.1) that fixed dependent version in gemspec manually.
