### PR TITLE
Add license to gemspec

### DIFF
--- a/guard-spork.gemspec
+++ b/guard-spork.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://rubygems.org/gems/guard-spork'
   s.summary     = 'Guard gem for Spork'
   s.description = 'Guard::Spork automatically manage Spork DRb servers.'
+  s.license     = 'MIT'
 
   s.required_ruby_version     = '>= 1.9.3'
   s.required_rubygems_version = '>= 1.3.6'


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.